### PR TITLE
Ditching Shapeless in favor of simplicity

### DIFF
--- a/src/main/scala/Example.scala
+++ b/src/main/scala/Example.scala
@@ -1,30 +1,46 @@
-import java.util.UUID
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import scala.concurrent.duration._
-import distance.Distance.Manhattan
-import distance.Point
+import distance.{Point, TenDimensionalPoint, ThreeDimensionalPoint, TwoDimensionalPoint}
 import tree.KDTree
 
 import scala.concurrent.Future
 
 object Example extends App {
-  val query: Point = Point(0,100)
-  val m: Int = 50
-  val n: Int = 200000
+  val query = TenDimensionalPoint(
+    0,
+    10,
+    5,
+    20,
+//    50,
+//    2,
+//    9,
+//    100,
+//    50,
+//    23,
+//    8
+  )
+
+  val m: Int = 20
+  val n: Int = 1000000
 
   val (data, _) = time("Generate data"){
     (1 to n)
       .par
-      .map{_=>Point.random(Range.inclusive(10, 2000), Range.inclusive(10, 2000))}
+      .map{_=>Point.random10D(Range.inclusive(10, 2000))}
       .distinct
       .toList
   }
+//
+//  println(data)
+// Case 1:
+//  val data = List(TenDimensionalPoint(1893.3742509642152,977.955660030486,1205.6199944801417,1319.5362250394828), TenDimensionalPoint(1218.8880545801535,800.4541297758566,633.8129949963233,942.3068595155291), TenDimensionalPoint(354.7107880477819,1231.3462404494605,1140.4790767133825,915.2715384914015), TenDimensionalPoint(255.38651590679956,1209.5431260809958,60.93122293876118,1078.019915533872), TenDimensionalPoint(1359.4689061306292,1067.6335755588289,1562.1642718419787,1361.8810308900809), TenDimensionalPoint(41.695980257061706,720.6179010356992,827.5893868774418,27.126635964562404), TenDimensionalPoint(1954.8266296157913,1915.9426099419688,1699.4104489668562,748.2289778756423), TenDimensionalPoint(195.86605747924773,1184.7555883682655,1894.841661648757,711.5349607859688), TenDimensionalPoint(620.1724018839553,563.5001541913509,737.2779230370123,678.5343754762877), TenDimensionalPoint(553.3879676405838,1944.9367358012082,1598.4970897682842,218.64127293947263))
 
-
+//Case 2:
+//  val data = List(TenDimensionalPoint(1218.888054860035,1936.0441039571838,1915.942602015348,1913.366330301771), TenDimensionalPoint(748.2289712474771,531.4947679209037,1570.3141897580726,28.371226975028467), TenDimensionalPoint(1359.4689061306292,1067.6335755588289,1562.1642718419787,1361.8810308900809), TenDimensionalPoint(354.7107880477819,1231.3462404494605,1140.4790767133825,915.2715384914015), TenDimensionalPoint(255.38651590679956,1209.5431260809958,60.93122293876118,1078.019915533872), TenDimensionalPoint(1893.3742268636227,88.41784907965935,977.9556574019479,897.0161060477823), TenDimensionalPoint(1319.5361963976418,1949.2480429071684,1263.8559892005135,1699.3978638813894), TenDimensionalPoint(195.86605747924773,1184.7555883682655,1894.841661648757,711.5349607859688), TenDimensionalPoint(620.1724018839553,563.5001541913509,737.2779230370123,678.5343754762877), TenDimensionalPoint(553.3879676405838,1944.9367358012082,1598.4970897682842,218.64127293947263))
 
   val (tree, _) = Await.result(timeFuture("Tree growth"){KDTree.grow(data)}, 60 seconds)
+
   val (bruteMNN, bruteSearchTime) = time("Brute Force Search"){data
     .par
     .map{p=> (p, p.distance(query))}
@@ -42,6 +58,8 @@ object Example extends App {
   println(s"Neighbors Tree       : ${treeMNN.map(_._1.id)}")
   println(s"Neighbors Brute Force: ${bruteMNN.map(_._1.id)}")
 
+//  println(treeMNN)
+//  println(bruteMNN)
 
   def time[R](name: String)(fn: => R): (R, Double) = {
     val t0 = System.nanoTime()
@@ -61,5 +79,4 @@ object Example extends App {
       (result, lapsed)
     }
   }
-
 }

--- a/src/main/scala/Example.scala
+++ b/src/main/scala/Example.scala
@@ -1,17 +1,20 @@
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import scala.concurrent.duration._
-import distance.{Point, FourDimensionalPoint}
+import distance.Point
+import distance.Point.DataPoint
 import tree.KDTree
 
 import scala.concurrent.Future
 
 object Example extends App {
-  val query = FourDimensionalPoint(
-    0,
-    10,
-    5,
-    20
+  val query = DataPoint(
+    List(
+      0,
+      10,
+      5,
+      20
+    )
   )
 
   val m: Int = 20
@@ -20,7 +23,7 @@ object Example extends App {
   val (data, _) = time("Generate data"){
     (1 to n)
       .par
-      .map{_=>Point.random10D(Range.inclusive(10, 2000))}
+      .map{_=>Point.randomPoint(Range.inclusive(10, 2000), 4)}
       .distinct
       .toList
   }

--- a/src/main/scala/Example.scala
+++ b/src/main/scala/Example.scala
@@ -1,28 +1,21 @@
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import scala.concurrent.duration._
-import distance.{Point, TenDimensionalPoint, ThreeDimensionalPoint, TwoDimensionalPoint}
+import distance.{Point, FourDimensionalPoint}
 import tree.KDTree
 
 import scala.concurrent.Future
 
 object Example extends App {
-  val query = TenDimensionalPoint(
+  val query = FourDimensionalPoint(
     0,
     10,
     5,
-    20,
-//    50,
-//    2,
-//    9,
-//    100,
-//    50,
-//    23,
-//    8
+    20
   )
 
   val m: Int = 20
-  val n: Int = 1000000
+  val n: Int = 100000
 
   val (data, _) = time("Generate data"){
     (1 to n)
@@ -57,9 +50,6 @@ object Example extends App {
   println(s"Farthest neighbor: Tree: ${treeMNN.head._1}, Brute Force: ${bruteMNN.head._1}")
   println(s"Neighbors Tree       : ${treeMNN.map(_._1.id)}")
   println(s"Neighbors Brute Force: ${bruteMNN.map(_._1.id)}")
-
-//  println(treeMNN)
-//  println(bruteMNN)
 
   def time[R](name: String)(fn: => R): (R, Double) = {
     val t0 = System.nanoTime()

--- a/src/main/scala/Example.scala
+++ b/src/main/scala/Example.scala
@@ -1,41 +1,15 @@
-package distance
-
 import java.util.UUID
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import scala.concurrent.duration._
 import distance.Distance.Manhattan
+import distance.Point
+import tree.KDTree
 
 import scala.concurrent.Future
 
-// Note to self: not all dissimilarity measures are useful for implementing the k-d tree algorithm in FBF (1976)
-// The dissimilarity measure must satisfy that the difference along a single axis is ALWAYS less or equal than
-// the total dissimilarity. For example, Euclidean distance doesn't cut it, but Manhattan distance does.
-case class Point(x: BigDecimal, y: BigDecimal) extends Manhattan[Point]{
-  val id: UUID = UUID.randomUUID()
-
-  override def canEqual(that: Any): Boolean = {
-    that match{
-      case other: Point => id.equals(other.id)
-      case _ => false
-    }
-  }
-}
-case class StrPoint(x: String, y: String)
-
-object Point{
-  val seed = 1000
-  val rnd = new scala.util.Random(seed)
-
-  def random(xRange: Range, yRange: Range) = {
-    val x = BigDecimal(rnd.nextDouble()*(xRange.end - xRange.start) + xRange.start)
-    val y = BigDecimal(rnd.nextDouble()*(yRange.end - yRange.start) + yRange.start)
-    Point(x, y)
-  }
-}
-
-object Hello extends App {
+object Example extends App {
   val query: Point = Point(0,100)
   val m: Int = 50
   val n: Int = 200000

--- a/src/main/scala/distance/Distance.scala
+++ b/src/main/scala/distance/Distance.scala
@@ -1,107 +1,28 @@
 package distance
 
-import java.util.UUID
-
-import distance.Distance.{GenericDataPoint, Manhattan}
-import shapeless.ops.hlist.{LeftFolder, Mapper, Zip, ZipConst}
-import shapeless.ops.tuple.ToList
-import shapeless.{::, Generic, HList, HNil}
-import generic.GenericUtils._
+import distance.ShapelessDistance.GenericDataPoint
 
 import scala.math.{acos, cos, sin}
 
-object Distance {
+trait Distance[T]{self: T =>
 
-  trait GenericDataPoint[T]{self:T=>
-    def repr[H <: HList]()(implicit gen: Generic.Aux[T, H]): H = {
-      gen.to(this)
+  def distance(other: T): BigDecimal
+
+  val features: List[BigDecimal]
+}
+
+object Distance{
+
+  trait Manhattan[T <: Distance[T]] extends Distance[T]{self:T=>
+
+    override def distance(other: T): BigDecimal = {
+      features
+        .zip(other.features)
+        .map{case (x, y)=>
+          (x-y).abs
+        }
+        .foldLeft(BigDecimal(0))(_ + _)
     }
-
-    def toList(implicit toList: ToList.Aux[T, BigDecimal, List[BigDecimal]]) = {
-      toList(self)
-    }
-  }
-
-  trait Euclidean[T] extends GenericDataPoint[T]{self:T =>
-
-    def distance[H<: HList, L<: HList](other: T)(
-      implicit gen: Generic.Aux[T, H],
-      zipper: Zip.Aux[H::H::HNil, L],
-      diffMapper: Mapper.Aux[sqDiffMap.type, L, H],
-      folder: LeftFolder.Aux[H, BigDecimal, reducerPoly.type, BigDecimal]
-    ): BigDecimal = {
-
-      BigDecimal(scala.math.pow(
-        repr
-          .zip(gen.to(other))
-          .map(sqDiffMap)
-          .foldLeft(BigDecimal(0))(reducerPoly).toDouble
-        ,
-        (1/BigDecimal(2)).toDouble
-      )
-      )
-    }
-  }
-
-  trait Minkowski[T <: Minkowski[T]] extends GenericDataPoint[T]{self: T=>
-
-    def distance[H<: HList, K<:HList, L<: HList](other: T, p: Int)(
-      implicit gen: Generic.Aux[T, H],
-      constZipper: ZipConst.Aux[Int, H, K],
-      zipper: Zip.Aux[K::H::HNil, L],
-      diffMapper: Mapper.Aux[diffMap.type, L, H],
-      folder: LeftFolder.Aux[H, BigDecimal, reducerPoly.type, BigDecimal]
-    ): BigDecimal = {
-      val repr = gen.to(this)
-
-      scala.math.pow(
-        repr
-          .zipConst(p)
-          .zip(gen.to(other))
-          .map(diffMap)
-          .foldLeft(BigDecimal(0))(reducerPoly).toDouble
-        ,
-        (1/BigDecimal(p)).toDouble
-      )
-    }
-  }
-
-  trait Manhattan[T] extends GenericDataPoint[T]{self: T=>
-
-    def distance[H<: HList, K<:HList, L<: HList](other: T)(
-      implicit gen: Generic.Aux[T, H],
-      zipper: Zip.Aux[H::H::HNil, L],
-      diffMapper: Mapper.Aux[absDiffMap.type, L, H],
-      folder: LeftFolder.Aux[H, BigDecimal, reducerPoly.type, BigDecimal]
-    ): BigDecimal = {
-      val repr = gen.to(this)
-
-      repr
-        .zip(gen.to(other))
-        .map(absDiffMap)
-        .foldLeft(BigDecimal(0))(reducerPoly)
-    }
-
-  }
-
-  trait Chebyshev[T] extends GenericDataPoint[T]{self: T=>
-
-    def distance[H <: HList, K<:HList, L<: HList](other: T)(
-      implicit gen: Generic.Aux[T, H],
-      zipper: Zip.Aux[H::H::HNil, L],
-      diffMapper: Mapper.Aux[absDiffMap.type, L, H],
-      folder: LeftFolder.Aux[H, BigDecimal, maxReducer.type, BigDecimal]
-    ): BigDecimal = {
-
-      val repr = gen.to(this)
-
-      repr
-        .zip(gen.to(other))
-        .map(absDiffMap)
-        .foldLeft(BigDecimal(0))(maxReducer)
-
-    }
-
   }
 
   implicit class Levenshtein(t1: String){
@@ -117,7 +38,6 @@ object Distance {
         )
       }
     }
-
   }
 
   //TODO: WIP
@@ -132,84 +52,5 @@ object Distance {
           + cos(longitude)*cos(other.longitude)*cos((longitude - other.longitude).abs)
       )
     }
-  }
-}
-
-// Note to self: not all dissimilarity measures are useful for implementing the k-d tree algorithm in FBF (1976)
-// The dissimilarity measure must satisfy that the difference along a single axis is ALWAYS less or equal than
-// the total dissimilarity. For example, Euclidean distance doesn't cut it, but Manhattan distance does.
-case class ThreeDimensionalPoint(x: BigDecimal, y: BigDecimal, z: BigDecimal) extends Manhattan[ThreeDimensionalPoint] with Identifiable
-case class TwoDimensionalPoint(x: BigDecimal, y: BigDecimal) extends Manhattan[TwoDimensionalPoint] with Identifiable
-case class FourDimensionalPoint(d0: BigDecimal,
-                                d1: BigDecimal,
-                                d2: BigDecimal,
-                                d3: BigDecimal
-                              ) extends Manhattan[FourDimensionalPoint] with Identifiable
-
-case class StrPoint(x: String, y: String)
-
-trait Identifiable{
-  val id: UUID = {
-    val byteArray = new Array[Byte](16)
-    Point.rnd.nextBytes(byteArray)
-    UUID.nameUUIDFromBytes(byteArray)
-  }
-
-  def canEqual(that: Any): Boolean = {
-    that match{
-      case other: Identifiable => id.equals(other.id)
-      case _ => false
-    }
-  }
-}
-
-object Point{
-  val seed = 1000
-  val rnd = new scala.util.Random(seed)
-
-  private def getRandomBigDecimal(range: Range) =
-    BigDecimal(rnd.nextDouble()*(range.end - range.start) + range.start)
-
-  def random2D(range: Range) = {
-    TwoDimensionalPoint(
-      getRandomBigDecimal(range),
-      getRandomBigDecimal(range)
-    )
-  }
-
-  def random3D(range: Range) = {
-    ThreeDimensionalPoint(
-      getRandomBigDecimal(range),
-      getRandomBigDecimal(range),
-      getRandomBigDecimal(range)
-    )
-  }
-
-  def random10D(range: Range) = {
-    FourDimensionalPoint(
-      getRandomBigDecimal(range),
-      getRandomBigDecimal(range),
-      getRandomBigDecimal(range),
-      getRandomBigDecimal(range)
-    )
-  }
-
-  def findMaxRangeDimension[T <: GenericDataPoint[T]](data: List[T])(
-    implicit toList: ToList.Aux[T, BigDecimal, List[BigDecimal]]): Int = {
-
-    val (minVals: List[BigDecimal], maxVals: List[BigDecimal]) = data
-      .tail
-      .foldLeft[(List[BigDecimal], List[BigDecimal])]((data.head.toList, data.head.toList)){case (cumulative, next)=>
-      (
-        cumulative._1.zip(next.toList).map{case (x0, x1)=> x0.min(x1)},
-        cumulative._2.zip(next.toList).map{case (x0, x1)=> x0.max(x1)}
-      )
-    }
-
-    minVals
-      .zip(maxVals)
-      .map{case (x, y)=> (x-y).abs}
-      .zipWithIndex
-      .maxBy{case (value, i)=> value}._2
   }
 }

--- a/src/main/scala/distance/Distance.scala
+++ b/src/main/scala/distance/Distance.scala
@@ -2,7 +2,7 @@ package distance
 
 import java.util.UUID
 
-import distance.Distance.{Euclidean, GenericDataPoint, Manhattan}
+import distance.Distance.{GenericDataPoint, Manhattan}
 import shapeless.ops.hlist.{LeftFolder, Mapper, Zip, ZipConst}
 import shapeless.ops.tuple.ToList
 import shapeless.{::, Generic, HList, HNil}
@@ -140,19 +140,11 @@ object Distance {
 // the total dissimilarity. For example, Euclidean distance doesn't cut it, but Manhattan distance does.
 case class ThreeDimensionalPoint(x: BigDecimal, y: BigDecimal, z: BigDecimal) extends Manhattan[ThreeDimensionalPoint] with Identifiable
 case class TwoDimensionalPoint(x: BigDecimal, y: BigDecimal) extends Manhattan[TwoDimensionalPoint] with Identifiable
-case class TenDimensionalPoint(d0: BigDecimal,
-                               d1: BigDecimal,
-                               d2: BigDecimal,
-                               d3: BigDecimal
-//                               ,
-//                               d4: BigDecimal,
-//                               d5: BigDecimal,
-//                               d6: BigDecimal,
-//                               d7: BigDecimal,
-//                               d8: BigDecimal,
-//                               d9: BigDecimal,
-//                               d10: BigDecimal,
-                              ) extends Manhattan[TenDimensionalPoint] with Identifiable
+case class FourDimensionalPoint(d0: BigDecimal,
+                                d1: BigDecimal,
+                                d2: BigDecimal,
+                                d3: BigDecimal
+                              ) extends Manhattan[FourDimensionalPoint] with Identifiable
 
 case class StrPoint(x: String, y: String)
 
@@ -194,19 +186,11 @@ object Point{
   }
 
   def random10D(range: Range) = {
-    TenDimensionalPoint(
+    FourDimensionalPoint(
       getRandomBigDecimal(range),
       getRandomBigDecimal(range),
       getRandomBigDecimal(range),
       getRandomBigDecimal(range)
-//      ,
-//      getRandomBigDecimal(range),
-//      getRandomBigDecimal(range),
-//      getRandomBigDecimal(range),
-//      getRandomBigDecimal(range),
-//      getRandomBigDecimal(range),
-//      getRandomBigDecimal(range),
-//      getRandomBigDecimal(range)
     )
   }
 

--- a/src/main/scala/distance/Point.scala
+++ b/src/main/scala/distance/Point.scala
@@ -1,0 +1,22 @@
+package distance
+
+object Point{
+  val seed = 1000
+  val rnd = new scala.util.Random(seed)
+
+  // Note to self: not all dissimilarity measures are useful for implementing the k-d tree algorithm in FBF (1976)
+  // The dissimilarity measure must satisfy that the difference along a single axis is ALWAYS less or equal than
+  // the total dissimilarity. For example, Euclidean distance doesn't cut it, but Manhattan distance does.
+  case class DataPoint(features: List[BigDecimal]) extends Distance.Manhattan[DataPoint] with Identifiable
+
+  case class StrPoint(x: String, y: String)
+
+  private def getRandomBigDecimal(range: Range) =
+    BigDecimal(rnd.nextDouble()*(range.end - range.start) + range.start)
+
+  def randomPoint(range: Range, dimension: Int): DataPoint = {
+    DataPoint(
+      (1 to dimension).toList.map(_=>getRandomBigDecimal(range))
+    )
+  }
+}

--- a/src/main/scala/distance/ShapelessDistance.scala
+++ b/src/main/scala/distance/ShapelessDistance.scala
@@ -1,0 +1,117 @@
+package distance
+
+import java.util.UUID
+
+import distance.ShapelessDistance.{GenericDataPoint, Manhattan}
+import shapeless.ops.hlist.{LeftFolder, Mapper, Zip, ZipConst}
+import shapeless.ops.tuple.ToList
+import shapeless.{::, Generic, HList, HNil}
+import generic.GenericUtils._
+
+import scala.math.{acos, cos, sin}
+
+object ShapelessDistance {
+
+  trait GenericDataPoint[T]{self:T=>
+    def repr[H <: HList]()(implicit gen: Generic.Aux[T, H]): H = {
+      gen.to(this)
+    }
+
+    def toList(implicit toList: ToList.Aux[T, BigDecimal, List[BigDecimal]]) = {
+      toList(self)
+    }
+  }
+
+  trait Euclidean[T] extends GenericDataPoint[T]{self:T =>
+
+    def distance[H<: HList, L<: HList](other: T)(
+      implicit gen: Generic.Aux[T, H],
+      zipper: Zip.Aux[H::H::HNil, L],
+      diffMapper: Mapper.Aux[sqDiffMap.type, L, H],
+      folder: LeftFolder.Aux[H, BigDecimal, reducerPoly.type, BigDecimal]
+    ): BigDecimal = {
+
+      BigDecimal(scala.math.pow(
+        repr
+          .zip(gen.to(other))
+          .map(sqDiffMap)
+          .foldLeft(BigDecimal(0))(reducerPoly).toDouble
+        ,
+        (1/BigDecimal(2)).toDouble
+      )
+      )
+    }
+  }
+
+  trait Minkowski[T <: Minkowski[T]] extends GenericDataPoint[T]{self: T=>
+
+    def distance[H<: HList, K<:HList, L<: HList](other: T, p: Int)(
+      implicit gen: Generic.Aux[T, H],
+      constZipper: ZipConst.Aux[Int, H, K],
+      zipper: Zip.Aux[K::H::HNil, L],
+      diffMapper: Mapper.Aux[diffMap.type, L, H],
+      folder: LeftFolder.Aux[H, BigDecimal, reducerPoly.type, BigDecimal]
+    ): BigDecimal = {
+      val repr = gen.to(this)
+
+      scala.math.pow(
+        repr
+          .zipConst(p)
+          .zip(gen.to(other))
+          .map(diffMap)
+          .foldLeft(BigDecimal(0))(reducerPoly).toDouble
+        ,
+        (1/BigDecimal(p)).toDouble
+      )
+    }
+  }
+
+  trait Manhattan[T] extends GenericDataPoint[T]{self: T=>
+
+    def distance[H<: HList, K<:HList, L<: HList](other: T)(
+      implicit gen: Generic.Aux[T, H],
+      zipper: Zip.Aux[H::H::HNil, L],
+      diffMapper: Mapper.Aux[absDiffMap.type, L, H],
+      folder: LeftFolder.Aux[H, BigDecimal, reducerPoly.type, BigDecimal]
+    ): BigDecimal = {
+      val repr = gen.to(this)
+
+      repr
+        .zip(gen.to(other))
+        .map(absDiffMap)
+        .foldLeft(BigDecimal(0))(reducerPoly)
+    }
+
+  }
+
+  trait Chebyshev[T] extends GenericDataPoint[T]{self: T=>
+
+    def distance[H <: HList, K<:HList, L<: HList](other: T)(
+      implicit gen: Generic.Aux[T, H],
+      zipper: Zip.Aux[H::H::HNil, L],
+      diffMapper: Mapper.Aux[absDiffMap.type, L, H],
+      folder: LeftFolder.Aux[H, BigDecimal, maxReducer.type, BigDecimal]
+    ): BigDecimal = {
+
+      val repr = gen.to(this)
+
+      repr
+        .zip(gen.to(other))
+        .map(absDiffMap)
+        .foldLeft(BigDecimal(0))(maxReducer)
+    }
+  }
+}
+
+trait Identifiable{
+  val id: UUID = UUID.randomUUID()
+
+  def canEqual(that: Any): Boolean = {
+    that match{
+      case other: Identifiable => id.equals(other.id)
+      case _ => false
+    }
+  }
+}
+
+

--- a/src/main/scala/generic/GenericUtils.scala
+++ b/src/main/scala/generic/GenericUtils.scala
@@ -1,0 +1,40 @@
+package generic
+
+import shapeless.{Poly1, Poly2}
+
+object GenericUtils {
+
+  object diffMap extends Poly1{
+    type ZippedType = (BigDecimal, Int)
+    implicit def atBigDecimal: Case.Aux[((BigDecimal, Int), BigDecimal), BigDecimal] = at{case ((x, k), y) =>
+      (x - y).abs.pow(k)
+    }
+  }
+
+  object sqDiffMap extends Poly1{
+    type ZippedType = (BigDecimal, Int)
+    implicit def atBigDecimal: Case.Aux[(BigDecimal, BigDecimal), BigDecimal] = at{case (x, y) =>
+      (x - y).pow(2)
+    }
+  }
+
+  object absDiffMap extends Poly1{
+    type ZippedType = (BigDecimal, Int)
+    implicit def atBigDecimal: Case.Aux[(BigDecimal, BigDecimal), BigDecimal] = at{case (x, y) =>
+      (x - y).abs
+    }
+  }
+
+  object reducerPoly extends Poly2{
+    implicit def atBigDecimal: Case.Aux[BigDecimal, BigDecimal, BigDecimal] = at{case (acc, n)=>
+      acc + n
+    }
+  }
+
+  object maxReducer extends Poly2{
+    implicit def atBigDecimal: Case.Aux[BigDecimal, BigDecimal, BigDecimal] = at{case (acc, n)=>
+      acc.max(n)
+    }
+  }
+
+}

--- a/src/main/scala/tree/KDTree.scala
+++ b/src/main/scala/tree/KDTree.scala
@@ -1,134 +1,169 @@
 package tree
 
-import distance.Distance.Euclidean
-import distance.Point
-import shapeless.{HList, Nat, the}
-import shapeless.ops.hlist
-import shapeless.ops.hlist.At
+import distance.Distance.{Euclidean, Manhattan}
+import generic.GenericUtils.{reducerPoly, sqDiffMap, absDiffMap}
+import shapeless.ops.hlist.{LeftFolder, Mapper, Zip}
+import shapeless.{::, Generic, HList, HNil}
+import shapeless.ops.tuple.ToList
 
 import scala.concurrent.{ExecutionContext, Future}
 
-sealed trait KDTree[T <: Euclidean[T]]{
+sealed trait KDTree[T <: Manhattan[T]]{
 
   val upperBoundaries: List[Option[BigDecimal]]
   val lowerBoundaries: List[Option[BigDecimal]]
 
-  def nnSearch(m: Int, target: T, currentBest: List[(T, BigDecimal)] = Nil): List[(T, BigDecimal)]
-  def traverse(point: T): Leaf[T]
+  def nnSearch[H<: HList, L<: HList](m: Int, target: T, currentBest: List[(T, BigDecimal)] = Nil)(
+    implicit gen: Generic.Aux[T, H],
+    zipper: Zip.Aux[H::H::HNil, L],
+    diffMapper: Mapper.Aux[absDiffMap.type, L, H],
+    folder: LeftFolder.Aux[H, BigDecimal, reducerPoly.type, BigDecimal]
+  ): List[(T, BigDecimal)]
+//  def traverse(point: T): Leaf[T]
 }
 
-case class Leaf[T <: Euclidean[T]](point: T,
+case class Leaf[T <: Manhattan[T]](point: T,
                                    upperBoundaries: List[Option[BigDecimal]],
                                    lowerBoundaries: List[Option[BigDecimal]]) extends KDTree[T]{
 
-  override def nnSearch(m: Int, target: T, currentBest: List[(T, BigDecimal)]): List[(T, BigDecimal)] = {
+  override def nnSearch[H<: HList, L<: HList](m: Int, target: T, currentBest: List[(T, BigDecimal)] = Nil)(
+    implicit gen: Generic.Aux[T, H],
+    zipper: Zip.Aux[H::H::HNil, L],
+    diffMapper: Mapper.Aux[absDiffMap.type, L, H],
+    folder: LeftFolder.Aux[H, BigDecimal, reducerPoly.type, BigDecimal]
+  ): List[(T, BigDecimal)] = {
     val distanceToTarget: BigDecimal = target.distance(point)
 //   Take the m points with the shortest distances and then sort the list in descending order, so that the relevant neighbor is
 //    in the head of the list.
+//    println(s"visiting")
     ((point, distanceToTarget)::currentBest).sortBy{case (_, dist) => dist}.take(m).reverse
   }
 
-  override def traverse(point: T): Leaf[T] = this
+//  override def traverse(point: T): Leaf[T] = this
 }
 
-case class Node[T <: Euclidean[T]](axis: Nat,
+case class Node[T <: Manhattan[T]](axis: Int,
                    splitValue: BigDecimal,
                    upperBoundaries: List[Option[BigDecimal]],
                    lowerBoundaries: List[Option[BigDecimal]],
                    left: KDTree[T],
-                   right: KDTree[T]) extends KDTree[T]{
+                   right: KDTree[T])(
+    implicit toList: ToList.Aux[T, BigDecimal, List[BigDecimal]]
+) extends KDTree[T]{
 
   import KDTree._
 
-  def nnSearch(m: Int, target: T, currentBest: List[(T, BigDecimal)] = Nil): List[(T, BigDecimal)] = {
+  def nnSearch[H<: HList, L<: HList](m: Int,
+               target: T,
+               currentBest: List[(T, BigDecimal)] = Nil)(
+    implicit gen: Generic.Aux[T, H],
+    zipper: Zip.Aux[H::H::HNil, L],
+    diffMapper: Mapper.Aux[absDiffMap.type, L, H],
+    folder: LeftFolder.Aux[H, BigDecimal, reducerPoly.type, BigDecimal]
+  ): List[(T, BigDecimal)] = {
 
 //  Search left first, then right
-    if(sortByAxis(axis)(target) <= splitValue){
+    if({
+      val asList = target.toList
+      asList(axis) <= splitValue
+    } ){
 
       val updatedBest = left.nnSearch(m, target, currentBest)
 
       if(ballWithinBounds(m, target, left.upperBoundaries, left.lowerBoundaries, updatedBest)){
         updatedBest
-      } else {
+      } else
+      if (boundsOverlapBall(m, target, upperBoundaries, lowerBoundaries, updatedBest)){
         right.nnSearch(m, target, updatedBest)
-      }
+      } else updatedBest
 
-//  Search right first, then right
+//  Search right first, then left
     } else {
 
       val updatedBest = right.nnSearch(m, target, currentBest)
 
-      if(ballWithinBounds(m, target, left.upperBoundaries, left.lowerBoundaries, updatedBest)){
+      if(ballWithinBounds(m, target, right.upperBoundaries, right.lowerBoundaries, updatedBest)){
         updatedBest
-      } else {
+      } else
+      if (boundsOverlapBall(m, target, upperBoundaries, lowerBoundaries, updatedBest)){
         left.nnSearch(m, target, updatedBest)
-      }
-
+      } else updatedBest
     }
   }
 
 
-  def traverse[L <: HList, N <: Nat](point: T)
-                        (implicit at: hlist.At.Aux[L, Nat, BigDecimal]): Leaf[T] = {
-
-    val repr: L = point.repr()
-    if(lowerThanByAxis(repr, axis, splitValue)) traverseOrReturn(point, left) else traverseOrReturn(point, right)
-  }
-
-  private def lowerThanByAxis[N <: Nat](pointRepr: HList, axis: N, split: BigDecimal)
-                                           (implicit at: hlist.At.Aux[L, Nat, BigDecimal]): Boolean = {
-
-    at(pointRepr, axis) <= split
-
-  }
-
-  private def traverseOrReturn[L <: KDTree[T]](point: T, nextNode: L): Leaf[T] = {
-    nextNode match{
-      case leaf: Leaf[T] => leaf
-      case node: Node[T] => node.traverse(point)
-    }
-  }
-
+//  def traverse[L <: HList, N <: Nat](point: T)
+//                        (implicit at: hlist.At.Aux[L, Nat, BigDecimal]): Leaf[T] = {
+//
+//    val repr = point.repr()
+//    val nextNode = if(at(repr, axis) <= splitValue) left else right
+//    nextNode match{
+//      case leaf: Leaf[T] => leaf
+//      case node: Node[T] => node.traverse(point)(at)
+//    }
+//  }
 }
 
 object KDTree {
 
-  def grow[T <: Euclidean[T], N <: Nat](data: List[T],
-           axis: Option[N] = None,
-           upperBoundaries: List[Option[BigDecimal]] = List(None, None),
-           lowerBoundaries: List[Option[BigDecimal]] = List(None, None))
-          (implicit ec: ExecutionContext): Future[KDTree[T]] ={
+  def grow[T <: Manhattan[T]](data: List[T],
+                              i: Int = 0,
+           upperBoundaries: List[Option[BigDecimal]] = Nil,
+           lowerBoundaries: List[Option[BigDecimal]] = Nil)
+          (
+            implicit ec: ExecutionContext,
+           toList: ToList.Aux[T, BigDecimal, List[BigDecimal]]
+          ): Future[KDTree[T]] ={
 
-    val nextAxis = getNextAxis()
-//    TODO:Use the nextAxis value above for the expressions below instead of simply axis
+    val nextAxis: Int = getNextAxis(data, i)
+
+    val (filledLowerBoundaries, filledUpperBoundaries) = {
+      if(upperBoundaries == Nil && lowerBoundaries == Nil){
+        (
+          data.head.toList.map{_=> None},
+          data.head.toList.map{_=> None}
+        )
+      }
+      else (lowerBoundaries, upperBoundaries)
+    }
 
     data match{
       case Nil => throw new Exception("No data to index.")
-      case point::Nil =>
+      case l:List[T] if l.size == 1 =>
         Future.successful(
-        Leaf(point, upperBoundaries, lowerBoundaries)
+          Leaf(l.head, filledUpperBoundaries, filledLowerBoundaries)
       )
       case l: List[T] =>
-        val split = median(l, axis)(mapperForAxis(axis))
+        val split = median(l, nextAxis){p: T =>
+          val listRepr: List[BigDecimal] = p.toList
+          listRepr(nextAxis)
+        }
 
-        val leftData: List[T] = data.filter(filterByAxis(axis, split, true))
-        val rightData: List[T] = data.filter(filterByAxis(axis, split, false))
+        val leftData: List[T] = data.filter{p:T =>
+          val listRepr: List[BigDecimal] = p.toList
+          listRepr(nextAxis) <= split
+        }
 
-        val leftUpperBoundaries = updateBoundary(upperBoundaries, split, axis)
-        val rightLowerBoundaries = updateBoundary(lowerBoundaries, split, axis)
+        val rightData: List[T] = data.filter{p:T =>
+          val listRepr: List[BigDecimal] = p.toList
+          listRepr(nextAxis) > split
+        }
 
-        val leftSon = grow(leftData, getNextAxis(leftData), leftUpperBoundaries, lowerBoundaries)
-        val rightSon = grow(rightData, getNextAxis(rightData), upperBoundaries, rightLowerBoundaries)
+        val leftUpperBoundaries = updateBoundary(filledUpperBoundaries, split, nextAxis)
+        val rightLowerBoundaries = updateBoundary(filledLowerBoundaries, split, nextAxis)
+
+        val leftSon = grow(leftData, nextAxis, leftUpperBoundaries, filledLowerBoundaries)
+        val rightSon = grow(rightData, nextAxis, filledUpperBoundaries, rightLowerBoundaries)
 
         for{
           left <- leftSon
           right <- rightSon
         } yield {
           Node(
-            axis,
+            nextAxis,
             split,
-            upperBoundaries,
-            lowerBoundaries,
+            filledUpperBoundaries,
+            filledLowerBoundaries,
             left,
             right
           )
@@ -136,7 +171,9 @@ object KDTree {
     }
   }
 
-  def median[T <: Euclidean[T]](data: List[T], axis: Nat)(mapper: T => BigDecimal): BigDecimal = {
+  def median[T <: Manhattan[T]](data: List[T], axis: Int)(mapper: T => BigDecimal)(
+    implicit toList: ToList.Aux[T, BigDecimal, List[BigDecimal]]
+  ): BigDecimal = {
     val mapped = data.sortBy(sortByAxis(axis)).par.map(mapper)
     if(mapped.length % 2 == 0){
       mapped(mapped.size/2 - 1) + (mapped(mapped.size - mapped.size/2) - mapped(mapped.size/2 - 1))/2.0
@@ -145,39 +182,23 @@ object KDTree {
     }
   }
 
-  private def mapperForAxis[T <: Euclidean[T], N<: Nat](axis: N)
-                                                       (implicit at: At.Aux[T, N, BigDecimal]): T => BigDecimal = {
-    p: T => at(p, axis)
-  }
-
-  private def filterByAxis[T <: Euclidean[T], N <: Nat](currentAxis: N, split: BigDecimal, left: Boolean)
-                                    (implicit at: At.Aux[T, N, BigDecimal]): T => Boolean = {
-    p: T =>
-      val coordinate = at(p, currentAxis)
-      if(left) coordinate <= split
-      else coordinate > split
-  }
-
   private def updateBoundary(boundary: List[Option[BigDecimal]], splitValue: BigDecimal, dimension: Int): List[Option[BigDecimal]] = {
-    if(dimension == 0){
-      Some(splitValue)::boundary.tail
-    } else{
-      boundary.head::List(Some(splitValue))
-    }
+    boundary.updated(dimension, Some(splitValue))
   }
 
-  def sortByAxis[T, N<:Nat](currentAxis: Nat)(
-                                           implicit at: At.Aux[T, N, BigDecimal]
-  ) = {
-    p: T => at(p, currentAxis)
-
+  def sortByAxis[T <: Manhattan[T]](currentAxis: Int)(implicit toList: ToList.Aux[T, BigDecimal, List[BigDecimal]]): T => BigDecimal = { p: T =>
+    val asList = p.toList
+    asList(currentAxis)
   }
 
-  def ballWithinBounds[T <: Euclidean[T]](m: Int,
+  def ballWithinBounds[T <: Manhattan[T]](
+                       m: Int,
                        query: T,
                        upperBound: List[Option[BigDecimal]],
                        lowerBound: List[Option[BigDecimal]],
-                       mNN: List[(T, BigDecimal)]): Boolean = {
+                       mNN: List[(T, BigDecimal)])(
+    implicit toList: ToList.Aux[T, BigDecimal, List[BigDecimal]]
+  ): Boolean = {
 
     mNN match{
       case _: List[(T, BigDecimal)] if mNN.size < m => false
@@ -185,23 +206,91 @@ object KDTree {
 
         val mDistance = mNN.head._2
 
-        if(
-          lowerBound.head.exists(query.x.coordinateDistance(_) <= mDistance) ||
-            upperBound.head.exists(query.x.coordinateDistance(_) <= mDistance)) false
-        else if(
-          lowerBound.tail.head.exists(query.y.coordinateDistance(_) <= mDistance) ||
-            upperBound.tail.head.exists(query.y.coordinateDistance(_) <= mDistance) ) false
-        else true
+        val zipped = lowerBound.zip(upperBound).zipWithIndex
+
+        val returns = zipped.foldLeft(false){case (res, ((l, u), dim))=>
+          val asList: List[BigDecimal] = query.toList
+          val value: BigDecimal = asList(dim)
+
+            res ||
+              l.exists(value.coordinateDistance(_) <= mDistance) ||
+              u.exists(value.coordinateDistance(_) <= mDistance)
+
+        }
+
+        !returns
     }
   }
 
-  def getNextAxis[T <: Euclidean[T]](data: List[T]): Int = {
-    // Choose the dimension with the highest variance
-    val varX = data.maxBy(_.x).x - data.minBy(_.x).x
-    val varY = data.maxBy(_.y).y - data.minBy(_.y).y
+  def boundsOverlapBall[T <: Manhattan[T]](
+                        m: Int,
+                        query: T,
+                        upperBound: List[Option[BigDecimal]],
+                        lowerBound: List[Option[BigDecimal]],
+                        mNN: List[(T, BigDecimal)])(
+    implicit toList: ToList.Aux[T, BigDecimal, List[BigDecimal]]
+  ): Boolean = {
 
-    // Choose a pivot point along this dimension by obtaining the median
-      if(varX >= varY) 0 else 1
+    if(mNN.size < m) true
+    else {
+
+        query.toList.zipWithIndex.foldLeft(BigDecimal(0)){case (cumSum, (v, i))=>
+          (lowerBound(i), upperBound(i)) match {
+            case (Some(l), _) if v <= l =>
+              val coordDist = cumSum + v.coordinateDistance(l)
+              if(coordDist > mNN.head._2) return true
+              else coordDist
+
+            case (_, Some(u)) if v > u=>
+              val coordDist = cumSum + v.coordinateDistance(u)
+              if(coordDist > mNN.head._2) return true
+              else coordDist
+            case _ => return true
+          }
+//        if(lowerBound(i).exists(_ > v))
+//          lowerBound(i).map(v.coordinateDistance(_) + cumSum).getOrElse(cumSum)
+//        else if(upperBound(i).exists( _ < v)) upperBound(i).map(v.coordinateDistance(_) + cumSum).getOrElse(cumSum)
+//        else 0
+      } > mNN.head._2
+
+//
+//
+//
+//      val sum: Option[BigDecimal] =  {
+//        if(lowerBound.head.exists(_ > query.x)) lowerBound.head.map(query.x.coordinateDistance)
+//        else if(upperBound.head.exists( _ < query.x)) upperBound.head.map(query.x.coordinateDistance)
+//        else None
+//      }.flatMap{cumSum =>
+//        if(lowerBound.tail.head.exists(_ > query.y)) lowerBound.tail.head.map(query.y.coordinateDistance).map(_ + cumSum)
+//        else if(upperBound.tail.head.exists(_ < query.y)) upperBound.tail.head.map(query.y.coordinateDistance).map(_ + cumSum)
+//        else None
+//      }
+//
+//      sum.forall{_ > mNN.head._2}
+    }
+  }
+
+  def getNextAxis[T <: Manhattan[T]](data: List[T], current: Int)(
+    implicit toList: ToList.Aux[T, BigDecimal, List[BigDecimal]]
+  ): Int = {
+
+    val maxDims = data.head.toList.size - 1
+    if(current == maxDims ) 0 else current + 1
+
+//    val (minVals: List[BigDecimal], maxVals: List[BigDecimal]) = data
+//      .tail
+//      .foldLeft[(List[BigDecimal], List[BigDecimal])]((data.head.toList, data.head.toList)){case (cumulative, next)=>
+//      (
+//        cumulative._1.zip(next.toList).map{case (x0, x1)=> x0.min(x1)},
+//        cumulative._2.zip(next.toList).map{case (x0, x1)=> x0.max(x1)}
+//      )
+//    }
+//
+//    minVals
+//      .zip(maxVals)
+//      .map{case (x, y)=> (x-y).abs}
+//      .zipWithIndex
+//      .maxBy{case (value, _)=> value}._2
   }
 
   implicit class Coordinate(t1: BigDecimal){


### PR DESCRIPTION
Shapeless implicits overcomplicate function definitions and don't seem to propagate very well, so they end up affecting all functions downstream. I'd rather have a more easily extendable definition by now.